### PR TITLE
updates dockerfile to use latest jenkins lts build

### DIFF
--- a/setup/Dockerfile
+++ b/setup/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.263.1-lts-slim
+FROM jenkins/jenkins:lts-jdk11
 USER root
 RUN apt-get update && apt-get install -y apt-transport-https \
        ca-certificates curl gnupg2 \


### PR DESCRIPTION
The current DockerFile hardcodes an older version of Jenkins with vulnerabilities. This PR updates the DockerFile to apply the latest LTS Jenkins build.