### PR TITLE
Magic number in version removed.

### DIFF
--- a/setup/Dockerfile
+++ b/setup/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.263.1-lts-slim
+FROM jenkins/jenkins:latest
 USER root
 RUN apt-get update && apt-get install -y apt-transport-https \
        ca-certificates curl gnupg2 \
@@ -9,8 +9,8 @@ RUN add-apt-repository \
        "deb [arch=amd64] https://download.docker.com/linux/debian \
        $(lsb_release -cs) stable"
 RUN apt-get update && apt-get install -y docker-ce-cli
-RUN curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \ 
+RUN curl -L "https://github.com/docker/compose/releases/download/`curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/docker/compose/releases/latest | sed 's#.*tag/##g' && echo`/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \ 
     chmod +x /usr/local/bin/docker-compose && \ 
     ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
 USER jenkins
-RUN jenkins-plugin-cli --plugins blueocean:1.24.3
+RUN jenkins-plugin-cli --plugins blueocean


### PR DESCRIPTION
Magic number such as Jenkins,blueocean or docker-compose's version is replaced with latest available.
Also this fix the issue of 'github-branch-source (2.10.2) requires a greater version of Jenkins (2.271) than 2.263.1 in /usr/share/jenkins/jenkins.war'